### PR TITLE
Fix out-of-bounds selection bug

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -105,9 +105,16 @@ impl App {
                 items.push(bpf_program);
             }
 
-            let state = state.lock().unwrap();
+            let mut state = state.lock().unwrap();
             let mut data_buf = data_buf.lock().unwrap();
             if let Some(index) = state.selected() {
+                // If the selected index is out of bounds, unselect it.
+                // This can happen if a program exits while it's selected.
+                if index >= items.len() {
+                    state.select(None);
+                    continue;
+                }
+
                 let bpf_program = &items[index];
                 data_buf.push_back(PeriodMeasure {
                     cpu_time_percent: bpf_program.cpu_time_percent(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,12 @@ fn run_draw_loop<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> Result
 fn ui(f: &mut Frame, app: &mut App) {
     let rects = Layout::vertical([Constraint::Min(5), Constraint::Length(3)]).split(f.size());
 
+    // This can happen when the program exists while the user is viewing the graphs.
+    // In this case, we want to switch back to the table view.
+    if app.selected_program().is_none() && app.show_graphs {
+        app.show_graphs = false;
+    }
+
     if app.show_graphs {
         render_graphs(f, app, rects[0]);
     } else {


### PR DESCRIPTION
This fixes an out-of-bounds panic that happens when a selected eBPF program exits. We'll now clear the selection if the selected index is out-of-bounds. Also, we'll go back to the table view if the program we are currently charting exits.