### PR TITLE
Add systemd journal logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,11 @@ dependencies = [
  "crossterm",
  "libbpf-rs",
  "libbpf-sys",
+ "log",
  "nix 0.28.0",
  "procfs",
  "ratatui",
+ "systemd-journal-logger",
  "tui-input",
 ]
 
@@ -373,6 +375,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -738,6 +743,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemd-journal-logger"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f3848dd723f2a54ac1d96da793b32923b52de8dfcced8722516dac312a5b2a"
+dependencies = [
+ "log",
+ "rustix",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +816,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "value-bag"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.4.2"
 edition = "2021"
 
 [dependencies]
+log = "0.4.14"
+systemd-journal-logger = "2.1.1"
 libbpf-rs = "0.23.0"
 libbpf-sys = "1.4.0"
 crossterm = "0.27.0"


### PR DESCRIPTION
I want to log in to the systemd journal error messages that I can recover from while the TUI is active. This is in preparation for a new feature I'm working on. 

With this change to tail bpftop logs:
```
sudo journalctl -t bpftop -f
```