### PR TITLE
Default sort order to Total CPU % descending order

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -120,7 +120,7 @@ fn get_pid_map(link: &Option<Link>) -> HashMap<u32, Vec<Process>> {
 
 impl App {
     pub fn new() -> App {
-        App {
+        let mut app = App {
             mode: Mode::Table,
             table_state: TableState::default(),
             header_columns: [
@@ -141,7 +141,10 @@ impl App {
             selected_column: None,
             graphs_bpf_program: Arc::new(Mutex::new(None)),
             sorted_column: Arc::new(Mutex::new(SortColumn::NoOrder)),
-        }
+        };
+        // Default sort column is Total CPU % in descending order
+        app.sort_column(SortColumn::Descending(6));
+        app
     }
 
     pub fn start_background_thread(&self, iter_link: Option<Link>) {


### PR DESCRIPTION
bpftop now defaults to sorting by Total CPU % in descending order. This is the most useful sort order, as it shows the most CPU intensive BPF programs at the top of the list. This follows the same sort order as the `top` or `htop` tools.