### PR TITLE
chore(ci): run build and release on 20.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build_test_and_release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Pin to the 2020 LTS to compile against glibc 2.31 and hence support a wider range of glibc versions than the current 2.35+ provided by the ubuntu-22.04 runner.

This is the oldest glibc supported out of the box from GitHub Runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories