### PR TITLE
Use cross-rs to build binaries in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,18 +16,25 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: write
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v4.1.1
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y zlib1g-dev libelf-dev
+
+    - name: Install cross
+      run: cargo install cross --git https://github.com/cross-rs/cross
+
     - name: Test
-      run: cargo test
-    - name: clippy
-      run: cargo clippy --all --tests --all-features --no-deps
+      run: cross test --target ${{ matrix.target }}
+
+    - name: Clippy
+      run: cross clippy --target ${{ matrix.target }} --all --tests --all-features --no-deps
+
     - name: Build
-      run: cargo build --release
+      run: cross build --target ${{ matrix.target }} --release
 
     - name: Build RPM
       if: startsWith(github.ref, 'refs/tags/v')

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,10 +1,9 @@
 [build]
 xargo = false
 default-target = "x86_64-unknown-linux-gnu"
-pre-build = ["apt-get update && apt-get install -y zlib1g-dev libelf-dev"]
+
+[target.x86_64-unknown-linux-gnu]
+dockerfile = "dockerfiles/Dockerfile.x86_64"
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = [
-    "dpkg --add-architecture $CROSS_DEB_ARCH", 
-    "apt-get update && apt-get --assume-yes install zlib1g-dev:$CROSS_DEB_ARCH libelf-dev:$CROSS_DEB_ARCH"
-]
+dockerfile = "dockerfiles/Dockerfile.aarch64"

--- a/dockerfiles/Dockerfile.aarch64
+++ b/dockerfiles/Dockerfile.aarch64
@@ -1,0 +1,5 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
+
+RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
+RUN dpkg --add-architecture arm64
+RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64

--- a/dockerfiles/Dockerfile.x86_64
+++ b/dockerfiles/Dockerfile.x86_64
@@ -1,0 +1,3 @@
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
+
+RUN apt-get update && apt-get install --assume-yes zlib1g-dev libelf-dev clang


### PR DESCRIPTION
Previously we were building the binaries in CI using cargo directly. With this change we are using cross-rs to build the binaries and we now also target aarch64.