### PR TITLE
Use cloned_from() instead of clone() in app.rs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -276,8 +276,7 @@ impl App {
         self.max_eps = 0;
         self.max_runtime = 0;
         self.mode = Mode::Graph;
-        *self.graphs_bpf_program.lock().unwrap() = self.selected_program().clone();
-
+        self.graphs_bpf_program.lock().unwrap().clone_from(&self.selected_program());
     }
 
     pub fn show_table(&mut self) {


### PR DESCRIPTION
To silence the clippy warning:

```
warning: assigning the result of `Clone::clone()` may be inefficient
   --> src/app.rs:279:9
    |
279 |         *self.graphs_bpf_program.lock().unwrap() = self.selected_program().clone();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `self.graphs_bpf_program.lock().unwrap().clone_from(&self.selected_program())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `#[warn(clippy::assigning_clones)]` on by default
```
