### PR TITLE
Update Nix installation instructions (24.05 -> 24.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ sudo pacman -S bpftop
 ```
 
 ### Nix
-You can install bpftop from the NixOS 24.05 stable channel:
+You can install bpftop from the NixOS 24.11 stable channel:
 
 ```
-nix-channel --add https://nixos.org/channels/nixos-24.05 nixpkgs
+nix-channel --add https://nixos.org/channels/nixos-24.11 nixpkgs
 nix-channel --update
 nix-env -iA nixpkgs.bpftop
 ```


### PR DESCRIPTION
Nix 24.11 is now the default and apparently 24.05 will be dropped in about a month. [https://discourse.nixos.org/t/nixos-24-11-released/56811](https://discourse.nixos.org/t/nixos-24-11-released/56811)

Is this fine to update?