### PR TITLE
Add --version and --help flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -123,6 +123,7 @@ version = "0.5.2"
 dependencies = [
  "anyhow",
  "circular-buffer",
+ "clap",
  "crossterm",
  "libbpf-cargo",
  "libbpf-rs",
@@ -227,9 +228,9 @@ checksum = "4dacb91f972298e70fc507a2ffcaf1545807f1a36da586fb846646030adc542f"
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -237,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -249,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -261,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ nix = { version = "0.29.0", features = ["user"] }
 circular-buffer = "1.0.0"
 procfs = "0.17.0"
 tui-input = "0.11.0"
+clap = { version = "4.5.27", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use anyhow::{anyhow, Context, Result};
 use app::SortColumn;
 use app::{App, Mode};
 use bpf_program::BpfProgram;
+use clap::Parser;
 use crossterm::event::{self, poll, Event, KeyCode, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{
@@ -69,6 +70,21 @@ const SORT_INFO_FOOTER: &str = "(Esc) back";
 
 const PROCFS_BPF_STATS_ENABLED: &str = "/proc/sys/kernel/bpf_stats_enabled";
 
+#[derive(Parser, Debug)]
+#[command(
+    name = env!("CARGO_PKG_NAME"),
+    version = env!("CARGO_PKG_VERSION"),
+    long_version = concat!(
+        env!("CARGO_PKG_VERSION"), " created by ",
+        "Jose Fernandez"
+    ),
+    author = "Jose Fernandez",
+    about = env!("CARGO_PKG_DESCRIPTION"),
+    override_usage = "sudo bpftop"
+)]
+struct Bpftop {
+}
+
 impl From<&BpfProgram> for Row<'_> {
     fn from(bpf_program: &BpfProgram) -> Self {
         let height = 1;
@@ -115,6 +131,8 @@ impl Drop for TerminalManager {
 }
 
 fn main() -> Result<()> {
+    let _ = Bpftop::parse();
+    
     if !nix::unistd::Uid::current().is_root() {
         return Err(anyhow!("This program must be run as root"));
     }


### PR DESCRIPTION
This commit adds the clap crate to bpftop, enabling standardized --version and --help flags. The updated help output now explicitly instructs users to run the command with root privileges (e.g., using sudo).

Closes: https://github.com/Netflix/bpftop/issues/113