### PR TITLE
Loosen dependency version requirements for improved packaging compati…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ authors = ["Jose Fernandez <josef@netflix.com>"]
 libbpf-cargo = ">=0.24.4"
 
 [dependencies]
-tracing = "0.1.41"
-tracing-subscriber = "0.3.20"
-tracing-journald = "0.3.1"
+tracing = ">=0.1.41"
+tracing-subscriber = ">=0.3.20"
+tracing-journald = ">=0.3.1"
 libbpf-rs = ">=0.24.4"
 libbpf-sys = ">=1.5.0"
-crossterm = "0.28.1"
-anyhow = "1.0.99"
-ratatui = { version = "0.29.0", default-features = false, features = ['crossterm'] }
-nix = { version = "0.30.1", features = ["user"] }
-circular-buffer = "1.1.0"
-procfs = "0.17.0"
-tui-input = "0.14.0"
-clap = { version = "4.5.45", features = ["derive"] }
+crossterm = ">=0.28.1"
+anyhow = ">=1.0.99"
+ratatui = { version = ">=0.29.0", default-features = false, features = ['crossterm'] }
+nix = { version = ">=0.29.0", features = ["user"] }
+circular-buffer = ">=1.1.0"
+procfs = ">=0.17.0"
+tui-input = ">=0.14.0"
+clap = { version = ">=4.5.45", features = ["derive"] }


### PR DESCRIPTION
…bility

Allow broader version ranges for dependencies to improve compatibility with system-provided packages:

- Set tui-input to >=0.14.0
- Use >= constraints for other dependencies