### PR TITLE
Use semver-compatible version constraints instead of open-ended ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,19 +7,19 @@ license = "Apache-2.0"
 authors = ["Jose Fernandez <josef@netflix.com>"]
 
 [build-dependencies]
-libbpf-cargo = ">=0.24.4"
+libbpf-cargo = "0.24.4"
 
 [dependencies]
-tracing = ">=0.1.41"
-tracing-subscriber = ">=0.3.20"
-tracing-journald = ">=0.3.1"
-libbpf-rs = ">=0.24.4"
-libbpf-sys = ">=1.5.0"
-crossterm = ">=0.28.1"
-anyhow = ">=1.0.99"
-ratatui = { version = ">=0.29.0", default-features = false, features = ['crossterm'] }
-nix = { version = ">=0.29.0", features = ["user"] }
-circular-buffer = ">=1.1.0"
-procfs = ">=0.17.0"
-tui-input = ">=0.14.0"
-clap = { version = ">=4.5.45", features = ["derive"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.20"
+tracing-journald = "0.3.1"
+libbpf-rs = "0.24.4"
+libbpf-sys = "1.5.0"
+crossterm = "0.28.1"
+anyhow = "1.0.99"
+ratatui = { version = "0.29.0", default-features = false, features = ['crossterm'] }
+nix = { version = "0.29.0", features = ["user"] }
+circular-buffer = "1.1.0"
+procfs = "0.17.0"
+tui-input = "0.14.0"
+clap = { version = "4.5.45", features = ["derive"] }


### PR DESCRIPTION
Replace open-ended version ranges (>=X.Y.Z) with caret requirements (X.Y.Z) for all dependencies to follow best practices and address packaging concerns.