### PR TITLE
feat: add `bpf_link_info`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "clap",
  "crossterm",
  "libbpf-cargo",
- "libbpf-rs",
+ "libbpf-rs 0.25.0",
  "libbpf-sys",
  "nix",
  "procfs",
@@ -752,7 +752,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "libbpf-rs",
+ "libbpf-rs 0.24.4",
  "memmap2",
  "regex",
  "semver",
@@ -766,6 +766,18 @@ name = "libbpf-rs"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51b943363864472bf306570a7076cbfa84571a403b98f59d18af4c4135271ca"
+dependencies = [
+ "bitflags 2.11.0",
+ "libbpf-sys",
+ "libc",
+ "vsprintf",
+]
+
+[[package]]
+name = "libbpf-rs"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23d252d93e246c8787198369f06806c99c5077b5295be29505295f4e5426dc4"
 dependencies = [
  "bitflags 2.11.0",
  "libbpf-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ libbpf-cargo = "0.24.4"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 tracing-journald = "0.3.1"
-libbpf-rs = "0.24.4"
+libbpf-rs = "0.25.0"
 libbpf-sys = "1.5.0"
 crossterm = "0.29.0"
 anyhow = "1.0.99"
 ratatui = { version = "0.30.0", default-features = false, features = ['crossterm'] }
-nix = { version = "0.29.0", features = ["user"] }
+nix = { version = "0.29.0", features = ["user", "net"] }
 circular-buffer = "1.1.0"
 procfs = "0.18.0"
 tui-input = "0.15.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@
  */
 use crate::{
     bpf_program::{BpfProgram, Process},
-    helpers::program_type_to_string,
+    helpers::program_type_as_str,
 };
 use circular_buffer::CircularBuffer;
 use libbpf_rs::{query::ProgInfoIter, Iter, Link};
@@ -191,7 +191,7 @@ impl App {
                 let processes = pid_map.get(&prog.id).cloned().unwrap_or_default();
 
                 // Skip bpf program if it does not match filter
-                let bpf_type = program_type_to_string(prog.ty);
+                let bpf_type = program_type_as_str(&prog.ty);
                 if !filter_str.is_empty()
                     && !bpf_type.to_lowercase().contains(&filter_str)
                     && !prog_name.to_lowercase().contains(&filter_str)
@@ -463,7 +463,7 @@ mod tests {
         let mut app = App::new(1);
         let prog_1 = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -476,7 +476,7 @@ mod tests {
 
         let prog_2 = BpfProgram {
             id: 2,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -579,7 +579,7 @@ mod tests {
         let mut app = App::new(1);
         let prog_1 = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -592,7 +592,7 @@ mod tests {
 
         let prog_2 = BpfProgram {
             id: 2,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,

--- a/src/bpf_attachment.rs
+++ b/src/bpf_attachment.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 The bpftop Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use libbpf_rs::query::{
+    CgroupLinkInfo, KprobeMultiLinkInfo, LinkInfo, LinkInfoIter, LinkTypeInfo::*, NetNsLinkInfo,
+    NetfilterLinkInfo, NetkitLinkInfo, RawTracepointLinkInfo, SockMapLinkInfo, StructOpsLinkInfo,
+    TcxLinkInfo, TracingLinkInfo, UprobeMultiLinkInfo, XdpLinkInfo,
+};
+use nix::net::if_::if_indextoname;
+use ratatui::{style::Stylize as _, text::Line, widgets::ListItem};
+
+use crate::helpers::{attach_type_as_str, link_type_as_str};
+
+/// Collect and render all attachments used by the BPF program as a list of [`ListItem`]:
+///
+/// ```text
+/// BPF Links (<number-of-links-used>)
+///   ID <link-id>: <link-type>  <link-specific-metadata>
+///   ...
+/// TC Filters (<number-of-tc-filters-used>)
+///   <iface>(<ifindex>)  <direction>  [direct-action]
+///   ...
+/// ```
+pub(crate) fn render_prog_attachments<'a>(prog_id: u32) -> Vec<ListItem<'a>> {
+    // Collect BPF links
+    let links = LinkInfoIter::default()
+        .filter_map(move |link| (link.prog_id == prog_id).then_some(link))
+        .collect::<Vec<_>>();
+
+    let mut attachments = Vec::with_capacity(1 + links.len());
+    if !links.is_empty() {
+        attachments.push(ListItem::new(Line::from_iter([
+            "BPF Links".bold(),
+            format!(" ({})", links.len()).into(),
+        ])));
+
+        for link in links {
+            attachments.push(ListItem::new(render_bpf_link(link)));
+        }
+    }
+
+    attachments
+}
+
+/// Render the BPF link info as a [`Line`]: `  ID <link-id>: <link-type> <link-specific-metadata>`
+fn render_bpf_link<'a>(link: LinkInfo) -> Line<'a> {
+    let link_type = link_type_as_str(&link.info);
+    let metadata = match link.info {
+        RawTracepoint(info) => {
+            let RawTracepointLinkInfo { name } = info;
+            format!(" {}", name)
+        }
+        Tracing(info) => {
+            let TracingLinkInfo { attach_type } = info;
+            let attach = attach_type_as_str(&attach_type);
+
+            format!(" {}", attach)
+        }
+        Cgroup(info) => {
+            let CgroupLinkInfo {
+                cgroup_id,
+                attach_type,
+            } = info;
+            let attach = attach_type_as_str(&attach_type);
+
+            format!(" {} CgroupId({})", attach, cgroup_id)
+        }
+        Iter => "".into(),
+        NetNs(info) => {
+            let NetNsLinkInfo { ino, attach_type } = info;
+            let attach = attach_type_as_str(&attach_type);
+
+            format!(" {} Inode({})", attach, ino)
+        }
+        Xdp(info) => {
+            let XdpLinkInfo { ifindex } = info;
+            let ifname_cstr = if_indextoname(ifindex).unwrap_or_default();
+
+            format!(" {}({})", ifname_cstr.to_string_lossy(), ifindex)
+        }
+        StructOps(info) => {
+            let StructOpsLinkInfo { map_id } = info;
+            format!(" MapId({})", map_id)
+        }
+        Netfilter(info) => {
+            let NetfilterLinkInfo {
+                protocol_family,
+                hooknum,
+                priority,
+                flags,
+            } = info;
+            let nf_proto = match protocol_family as i32 {
+                libbpf_rs::NFPROTO_IPV4 => "IPv4",
+                libbpf_rs::NFPROTO_IPV6 => "IPv6",
+                _ => "",
+            };
+            let inet_hook = match hooknum as i32 {
+                libbpf_rs::NF_INET_PRE_ROUTING => "PreRouting",
+                libbpf_rs::NF_INET_LOCAL_IN => "LocalIn",
+                libbpf_rs::NF_INET_FORWARD => "Forward",
+                libbpf_rs::NF_INET_LOCAL_OUT => "LocalOut",
+                libbpf_rs::NF_INET_POST_ROUTING => "PostRouting",
+                _ => "",
+            };
+            let ip_defrag = if flags & libbpf_sys::BPF_F_NETFILTER_IP_DEFRAG != 0 {
+                "IpDefrag"
+            } else {
+                ""
+            };
+
+            format!(
+                " {} {} Priority({}) {}",
+                nf_proto, inet_hook, priority, ip_defrag
+            )
+        }
+        KprobeMulti(info) => {
+            let KprobeMultiLinkInfo {
+                count,
+                flags,
+                missed,
+            } = info;
+            let ret_probe = if flags & libbpf_sys::BPF_F_KPROBE_MULTI_RETURN != 0 {
+                "Return"
+            } else {
+                ""
+            };
+
+            format!(" Count({}) Missed({}) {}", count, missed, ret_probe)
+        }
+        UprobeMulti(info) => {
+            let UprobeMultiLinkInfo {
+                count, flags, pid, ..
+            } = info;
+            let ret_probe = if flags & libbpf_sys::BPF_F_UPROBE_MULTI_RETURN != 0 {
+                "Return"
+            } else {
+                ""
+            };
+
+            format!(" TargetPid({}) Count({}) {}", pid, count, ret_probe)
+        }
+        Tcx(info) => {
+            let TcxLinkInfo {
+                ifindex,
+                attach_type,
+            } = info;
+            let ifname_cstr = if_indextoname(ifindex).unwrap_or_default();
+            let attach = attach_type_as_str(&attach_type);
+
+            format!(" {}({}) {}", ifname_cstr.to_string_lossy(), ifindex, attach)
+        }
+        Netkit(info) => {
+            let NetkitLinkInfo {
+                ifindex,
+                attach_type,
+            } = info;
+            let ifname_cstr = if_indextoname(ifindex).unwrap_or_default();
+            let attach = attach_type_as_str(&attach_type);
+
+            format!(" {}({}) {}", ifname_cstr.to_string_lossy(), ifindex, attach)
+        }
+        SockMap(info) => {
+            let SockMapLinkInfo {
+                map_id,
+                attach_type,
+            } = info;
+            let attach = attach_type_as_str(&attach_type);
+
+            format!(" MapId({}) {}", map_id, attach)
+        }
+        PerfEvent => "".into(),
+        Unknown => "".into(),
+    };
+
+    Line::from_iter([
+        format!("  ID {}: {}", link.id, link_type).bold(),
+        metadata.into(),
+    ])
+}

--- a/src/bpf_program.rs
+++ b/src/bpf_program.rs
@@ -24,7 +24,7 @@ use std::{
 #[derive(Clone, Debug)]
 pub struct BpfProgram {
     pub id: u32,
-    pub bpf_type: String,
+    pub bpf_type: &'static str,
     pub name: String,
     pub prev_runtime_ns: u64,
     pub run_time_ns: u64,
@@ -104,7 +104,7 @@ mod tests {
     fn test_partial_eq() {
         let prog_1 = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -117,7 +117,7 @@ mod tests {
 
         let prog_2 = BpfProgram {
             id: 2,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -136,7 +136,7 @@ mod tests {
     fn test_period_average_runtime_ns() {
         let prog = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -153,7 +153,7 @@ mod tests {
     fn test_total_average_runtime_ns() {
         let prog = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 1000,
@@ -170,7 +170,7 @@ mod tests {
     fn test_runtime_delta() {
         let prog = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -187,7 +187,7 @@ mod tests {
     fn test_run_cnt_delta() {
         let prog = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -204,7 +204,7 @@ mod tests {
     fn test_events_per_second() {
         let prog = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100,
             run_time_ns: 200,
@@ -221,7 +221,7 @@ mod tests {
     fn test_cpu_time_percent() {
         let prog = BpfProgram {
             id: 1,
-            bpf_type: "test".to_string(),
+            bpf_type: "test",
             name: "test".to_string(),
             prev_runtime_ns: 100_000_000,
             run_time_ns: 200_000_000,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,7 +16,11 @@
  *  limitations under the License.
  *
  */
-use libbpf_rs::ProgramType;
+use libbpf_rs::{
+    query::LinkTypeInfo,
+    ProgramAttachType::{self, *},
+    ProgramType,
+};
 
 pub fn format_percent(num: f64) -> String {
     if num < 1.0 {
@@ -38,7 +42,7 @@ pub fn round_to_first_non_zero(num: f64) -> f64 {
     (num * multiplier).round() / multiplier
 }
 
-pub fn program_type_to_string(program_type: ProgramType) -> String {
+pub fn program_type_as_str(program_type: &ProgramType) -> &'static str {
     match program_type {
         ProgramType::Unspec => "Unspec",
         ProgramType::SocketFilter => "SocketFilter",
@@ -74,7 +78,89 @@ pub fn program_type_to_string(program_type: ProgramType) -> String {
         ProgramType::Syscall => "Syscall",
         _ => "Unknown",
     }
-    .to_string()
+}
+
+pub(crate) fn link_type_as_str(link_type: &LinkTypeInfo) -> &'static str {
+    match link_type {
+        LinkTypeInfo::RawTracepoint(_) => "RawTracepoint",
+        LinkTypeInfo::Tracing(_) => "Tracing",
+        LinkTypeInfo::Cgroup(_) => "Cgroup",
+        LinkTypeInfo::Iter => "Iter",
+        LinkTypeInfo::NetNs(_) => "NetNs",
+        LinkTypeInfo::Xdp(_) => "Xdp",
+        LinkTypeInfo::StructOps(_) => "StructOps",
+        LinkTypeInfo::Netfilter(_) => "Netfilter",
+        LinkTypeInfo::KprobeMulti(_) => "KprobeMulti",
+        LinkTypeInfo::UprobeMulti(_) => "UprobeMulti",
+        LinkTypeInfo::Tcx(_) => "Tcx",
+        LinkTypeInfo::Netkit(_) => "Netkit",
+        LinkTypeInfo::SockMap(_) => "SockMap",
+        LinkTypeInfo::PerfEvent => "PerfEvent",
+        _ => "Unknown",
+    }
+}
+
+pub(crate) fn attach_type_as_str(attach_type: &ProgramAttachType) -> &'static str {
+    match attach_type {
+        CgroupInetIngress => "CgroupInetIngress",
+        CgroupInetEgress => "CgroupInetEgress",
+        CgroupInetSockCreate => "CgroupInetSockCreate",
+        CgroupSockOps => "CgroupSockOps",
+        SkSkbStreamParser => "SkSkbStreamParser",
+        SkSkbStreamVerdict => "SkSkbStreamVerdict",
+        CgroupDevice => "CgroupDevice",
+        SkMsgVerdict => "SkMsgVerdict",
+        CgroupInet4Bind => "CgroupInet4Bind",
+        CgroupInet6Bind => "CgroupInet6Bind",
+        CgroupInet4Connect => "CgroupInet4Connect",
+        CgroupInet6Connect => "CgroupInet6Connect",
+        CgroupInet4PostBind => "CgroupInet4PostBind",
+        CgroupInet6PostBind => "CgroupInet6PostBind",
+        CgroupUdp4Sendmsg => "CgroupUdp4Sendmsg",
+        CgroupUdp6Sendmsg => "CgroupUdp6Sendmsg",
+        LircMode2 => "LircMode2",
+        FlowDissector => "FlowDissector",
+        CgroupSysctl => "CgroupSysctl",
+        CgroupUdp4Recvmsg => "CgroupUdp4Recvmsg",
+        CgroupUdp6Recvmsg => "CgroupUdp6Recvmsg",
+        CgroupGetsockopt => "CgroupGetsockopt",
+        CgroupSetsockopt => "CgroupSetsockopt",
+        TraceRawTp => "TraceRawTp",
+        TraceFentry => "TraceFentry",
+        TraceFexit => "TraceFexit",
+        ModifyReturn => "ModifyReturn",
+        LsmMac => "LsmMac",
+        TraceIter => "TraceIter",
+        CgroupInet4Getpeername => "CgroupInet4Getpeername",
+        CgroupInet6Getpeername => "CgroupInet6Getpeername",
+        CgroupInet4Getsockname => "CgroupInet4Getsockname",
+        CgroupInet6Getsockname => "CgroupInet6Getsockname",
+        XdpDevmap => "XdpDevmap",
+        CgroupInetSockRelease => "CgroupInetSockRelease",
+        XdpCpumap => "XdpCpumap",
+        SkLookup => "SkLookup",
+        Xdp => "Xdp",
+        SkSkbVerdict => "SkSkbVerdict",
+        SkReuseportSelect => "SkReuseportSelect",
+        SkReuseportSelectOrMigrate => "SkReuseportSelectOrMigrate",
+        PerfEvent => "PerfEvent",
+        KprobeMulti => "KprobeMulti",
+        NetkitPeer => "NetkitPeer",
+        TraceUprobeMulti => "TraceUprobeMulti",
+        LsmCgroup => "LsmCgroup",
+        TraceKprobeSession => "TraceKprobeSession",
+        TcxIngress => "TcxIngress",
+        TcxEgress => "TcxEgress",
+        Netfilter => "Netfilter",
+        CgroupUnixGetsockname => "CgroupUnixGetsockname",
+        CgroupUnixSendmsg => "CgroupUnixSendmsg",
+        NetkitPrimary => "NetkitPrimary",
+        CgroupUnixRecvmsg => "CgroupUnixRecvmsg",
+        CgroupUnixConnect => "CgroupUnixConnect",
+        CgroupUnixGetpeername => "CgroupUnixGetpeername",
+        StructOps => "StructOps",
+        _ => "Unknown",
+    }
 }
 
 #[cfg(test)]
@@ -90,7 +176,19 @@ mod tests {
 
     #[test]
     fn test_program_type_to_string() {
-        let str = program_type_to_string(ProgramType::CgroupSkb);
+        let str = program_type_as_str(&ProgramType::CgroupSkb);
         assert_eq!(str, "CgroupSkb");
+    }
+
+    #[test]
+    fn test_link_type_to_string() {
+        let str = link_type_as_str(&LinkTypeInfo::Iter);
+        assert_eq!(str, "Iter");
+    }
+
+    #[test]
+    fn test_attach_type_to_string() {
+        let str = attach_type_as_str(&ProgramAttachType::Xdp);
+        assert_eq!(str, "Xdp");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@
  *  limitations under the License.
  *
  */
-use crate::helpers::format_percent;
+use crate::{bpf_attachment::render_prog_attachments, helpers::format_percent};
 use anyhow::{anyhow, Context, Result};
 use app::SortColumn;
 use app::{App, Mode};
@@ -36,8 +36,8 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::Line;
 use ratatui::widgets::{
-    Axis, Block, BorderType, Borders, Cell, Chart, Dataset, GraphType, Padding, Paragraph, Row,
-    Scrollbar, ScrollbarOrientation, Table,
+    Axis, Block, BorderType, Borders, Cell, Chart, Dataset, GraphType, List, Padding, Paragraph,
+    Row, Scrollbar, ScrollbarOrientation, Table,
 };
 use ratatui::{symbols, Frame, Terminal};
 use std::fs;
@@ -53,6 +53,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tui_input::backend::crossterm::EventHandler;
 
 mod app;
+mod bpf_attachment;
 mod bpf_program;
 mod helpers;
 mod pid_iter {
@@ -500,30 +501,27 @@ fn render_graphs(f: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect::<Vec<_>>();
 
-    let mut items = vec![
+    let mut prog_info_rows = vec![
         Row::new(vec![Cell::from("Program ID"), Cell::from("Unknown")]),
         Row::new(vec![Cell::from("Program Type"), Cell::from("Unknown")]),
         Row::new(vec![Cell::from("Program Name"), Cell::from("Unknown")]),
     ];
-    let widths = [Constraint::Length(15), Constraint::Min(0)];
+    let mut attach_info_rows = vec![];
 
     if let Some(bpf_program) = app.graphs_bpf_program.lock().unwrap().clone() {
-        items = vec![
+        prog_info_rows = vec![
             Row::new(vec![
                 Cell::from("Program ID".bold()),
                 Cell::from(bpf_program.id.to_string()),
-            ])
-            .height(2),
+            ]),
             Row::new(vec![
                 Cell::from("Program Type".bold()),
                 Cell::from(bpf_program.bpf_type),
-            ])
-            .height(2),
+            ]),
             Row::new(vec![
                 Cell::from("Program Name".bold()),
                 Cell::from(bpf_program.name),
-            ])
-            .height(2),
+            ]),
             Row::new(vec![
                 Cell::from("PIDs".bold()),
                 Cell::from(
@@ -534,21 +532,32 @@ fn render_graphs(f: &mut Frame, app: &mut App, area: Rect) {
                         .collect::<Vec<String>>()
                         .join(", "),
                 ),
-            ])
-            .height(2),
+            ]),
         ];
+
+        attach_info_rows.extend(render_prog_attachments(bpf_program.id));
     }
 
-    let table = Table::new(items, widths)
-        .block(
-            Block::default()
-                .title(" Program Information ")
-                .padding(Padding::new(3, 0, 1, 0))
-                .borders(Borders::ALL),
-        )
-        .style(Style::default());
+    let info_block = Block::default()
+        .title(" Program Information ")
+        .padding(Padding::new(3, 0, 1, 0))
+        .borders(Borders::ALL);
+    let info_area = info_block.inner(sub_chunks[0][0]);
+    let info_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(prog_info_rows.len() as u16),
+            Constraint::Min(0),
+        ])
+        .split(info_area);
 
-    f.render_widget(table, sub_chunks[0][0]); // Top left
+    let prog_info = Table::new(prog_info_rows, [Constraint::Length(15), Constraint::Min(0)])
+        .style(Style::default());
+    let attach_info = List::new(attach_info_rows);
+
+    f.render_widget(info_block, sub_chunks[0][0]); // Top left
+    f.render_widget(prog_info, info_chunks[0]); // Top left - upper half
+    f.render_widget(attach_info, info_chunks[1]); // Top left - lower half
     f.render_widget(cpu_chart.clone(), sub_chunks[0][1]); // Top right
     f.render_widget(eps_chart, sub_chunks[1][0]); // Bottom left
     f.render_widget(runtime_chart, sub_chunks[1][1]); // Bottom right


### PR DESCRIPTION
~currently WIP, I'm currently working to get an API upstream for TC BPF filters in https://github.com/rust-netlink/netlink-packet-route~

Add attach info in the "Program Information" window:
- [x] bpf_link_info up to libbpf-rs ~v0.24.4 which only includes:~
~- [x] attach info for TC filter progs attached to clsact qdisc via netlink~ separated into another PR

