### PR TITLE
feat: add Nix flake dev shell for local development

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/
 rpmbuild/
 *.rpm
 src/bpf/pid_iter.skel.rs
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "bpftop - Dynamic real-time view of running eBPF programs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = fn:
+        nixpkgs.lib.genAttrs systems (system: fn nixpkgs.legacyPackages.${system});
+    in {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          # Nix's cc-wrapper injects hardening flags that are unsupported
+          # by the BPF target (used by libbpf-cargo to compile .bpf.c files).
+          # This is the same pattern used by systemd in nixpkgs.
+          hardeningDisable = [ "zerocallusedregs" "shadowstack" "pacret" ];
+
+          nativeBuildInputs = with pkgs; [
+            # Rust
+            cargo
+            rustc
+            rustfmt
+            clippy
+            rust-analyzer
+
+            # Build tools
+            pkg-config
+            llvmPackages.clang
+            gnumake
+
+            # Libraries
+            elfutils
+            zlib
+            libbpf
+          ];
+
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        };
+      });
+    };
+}


### PR DESCRIPTION
Provides a reproducible development environment with all system dependencies (clang, elfutils, zlib, libbpf) needed to build bpftop without cross or Docker. Uses selective hardeningDisable for BPF-incompatible flags (the same pattern used by systemd in nixpkgs). Activates automatically via direnv with `use flake`.