### PR TITLE
chore: pin GitHub Actions to major version tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       run: cargo install cross --git https://github.com/cross-rs/cross
 
     - name: Cache dependencies
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5
       with:
         path: ~/.cargo/bin
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -38,10 +38,10 @@ jobs:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
 
     - name: Restore dependencies from cache
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@v5
       with:
         path: ~/.cargo/bin
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -61,7 +61,7 @@ jobs:
       run: mv target/${{ matrix.target }}/release/bpftop target/${{ matrix.target }}/release/bpftop-${{ matrix.target }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v6.0.0
+      uses: actions/upload-artifact@v6
       with:
         name: bpftop-${{ matrix.target }}
         path: target/${{ matrix.target }}/release/bpftop-${{ matrix.target }}
@@ -75,14 +75,14 @@ jobs:
     steps:
     - name: Download all artifacts
       id: download_artifacts
-      uses: actions/download-artifact@v7.0.0
+      uses: actions/download-artifact@v7
       with:
         pattern: bpftop-*
         path: artifacts
         merge-multiple: true
 
     - name: Create Release and Upload Artifacts
-      uses: ncipollo/release-action@v1.20.0
+      uses: ncipollo/release-action@v1
       with:
         artifacts: artifacts/bpftop-*
         draft: true


### PR DESCRIPTION
Minor and patch releases for actions were generating constant Dependabot PRs with no meaningful changes. Pinning to major version tags (e.g. @v6 instead of @v6.0.2) lets us pick up fixes automatically while Dependabot only alerts on major bumps.