### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "bpftop"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "circular-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpftop"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Dynamic real-time view of running eBPF programs"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump version to 0.8.0 for the first release under the new repository home.

Changes since v0.7.1: process name filtering, ratatui/crossterm upgrade, Nix flake dev shell, ownership transfer, and dependency bumps.