### PR TITLE
ci: ignore ghost rand dependency in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,8 @@ updates:
       # Only security updates for Rust dependencies
       - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+      # Ghost dep: ratatui's optional termwiz backend pulls in
+      # phf 0.11 -> phf_generator -> rand 0.8. We don't enable
+      # termwiz, so rand is never compiled. See cargo#10801.
+      - dependency-name: "rand"
     rebase-strategy: "disabled"


### PR DESCRIPTION
## Summary

- Suppress Dependabot alerts and PRs for `rand`, which is a ghost dependency in `Cargo.lock`
- `rand` 0.8 is pulled in by ratatui's optional termwiz backend (`ratatui → ratatui-termwiz → termwiz → terminfo → phf 0.11 → phf_generator → rand 0.8`), but bpftop only enables the crossterm backend so the code is never compiled
- This is a known upstream Cargo issue ([cargo#10801](https://github.com/rust-lang/cargo/issues/10801)) with no fix available — the resolver includes optional deps in `Cargo.lock` regardless of activation

## Test plan

- [x] Alert #4 already dismissed via API
- [ ] Verify no new Dependabot PRs or alerts for `rand` after merge