### PR TITLE
ci: migrate from cross to native GitHub runners

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,13 +12,7 @@ Install required system dependencies first:
 sudo apt-get update && sudo apt-get install -y zlib1g-dev libelf-dev clang libbpf-dev
 ```
 
-Install the cross-compilation tool:
-```bash
-cargo install cross --git https://github.com/cross-rs/cross
-```
-
 ### Build Commands
-Use regular cargo for fast development builds:
 ```bash
 # Build for development - takes ~30 seconds
 cargo build
@@ -27,36 +21,16 @@ cargo build
 cargo build --release
 ```
 
-For cross-compilation (when needed):
-```bash
-# Build for x86_64 (may take 15+ minutes on first run due to Docker image building) 
-# NEVER CANCEL: Set timeout to 120+ minutes for cross builds due to potential network issues
-cross build --release --target x86_64-unknown-linux-gnu
-
-# Build for ARM64 - takes 15+ minutes on first run
-# NEVER CANCEL: Set timeout to 120+ minutes for cross builds due to potential network issues
-cross build --release --target aarch64-unknown-linux-gnu
-
-# Using make shortcut (calls cross build --release)
-make build
-```
-
 ### Testing
 ```bash
 # Run all tests - takes ~30 seconds. NEVER CANCEL.
 cargo test
-
-# Run tests with cross-compilation
-cross test --target x86_64-unknown-linux-gnu
 ```
 
 ### Code Quality
 ```bash
 # Run clippy linter - takes ~15 seconds
 cargo clippy --all --tests --all-features --no-deps
-
-# Run clippy with cross-compilation
-cross clippy --target x86_64-unknown-linux-gnu --all --tests --all-features --no-deps
 ```
 
 ## Running the Application
@@ -96,31 +70,16 @@ After making code changes, always test these scenarios:
 3. **Graph view**: Press Enter on a program to switch to graph view, then `q` to return to table view
 4. **Program termination**: Press `q` to quit cleanly
 
-### Cross-compilation Validation
-If cross-compilation is needed:
-```bash
-# Test x86_64 build - NEVER CANCEL: may take 120+ minutes on first run due to Docker and network issues
-cross build --target x86_64-unknown-linux-gnu --release
-
-# Test ARM64 build - NEVER CANCEL: may take 120+ minutes on first run due to Docker and network issues
-cross build --target aarch64-unknown-linux-gnu --release
-```
-
-**WARNING**: Cross-compilation builds Docker images which frequently fail with network connectivity issues to Ubuntu package repositories. If cross builds fail with "Temporary failure resolving" errors, this is a known issue. Use regular cargo builds for development and testing.
-
 ## Critical Build Information
 
 ### Timing Expectations
 - **cargo test**: ~30 seconds - NEVER CANCEL, set timeout to 90+ seconds
 - **cargo build**: ~30 seconds for debug, ~45 seconds for release - set timeout to 90+ seconds
 - **cargo clippy**: ~15 seconds - set timeout to 60+ seconds
-- **cross build**: 15-120+ minutes on first run (Docker image building with potential network issues) - NEVER CANCEL, set timeout to 150+ minutes
-- **cross test**: 5-60+ minutes - NEVER CANCEL, set timeout to 90+ minutes
 
 ### Dependencies and Requirements
 - **System packages**: zlib1g-dev, libelf-dev, clang, libbpf-dev
 - **Rust toolchain**: Standard Rust installation with cargo
-- **Cross-compilation**: cross tool (installs via cargo)
 - **Runtime**: Linux with eBPF support, sudo privileges required
 
 ### Build Process Details
@@ -137,13 +96,10 @@ This means changes to BPF C code require a full rebuild.
 - **Platform support**: Primarily tested on Linux x86_64 and ARM64
 - **BPF statistics**: Only enabled while the application is running to minimize system overhead
 - **Real-time updates**: UI refreshes every second with new statistics
-- **Cross-compilation issues**: Docker builds may fail due to Ubuntu package repository connectivity issues
-
 ## Common Issues
 
 ### Build Failures
 - **Missing dependencies**: Install zlib1g-dev, libelf-dev, clang, libbpf-dev
-- **Cross build Docker failures**: Use regular cargo builds if cross builds fail with network errors
 - **Permission errors**: Ensure sudo access for running the application
 
 ### Runtime Issues  
@@ -159,5 +115,3 @@ Key files and directories:
 - `src/bpf_program.rs`: eBPF program data structures and statistics calculation
 - `src/bpf/`: BPF C source code and header files
 - `build.rs`: Build script for compiling BPF code and generating Rust bindings
-- `Cross.toml`: Cross-compilation configuration
-- `dockerfiles/`: Docker configurations for cross-compilation targets

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
         uses: anthropics/claude-code-action@1c8b699d43e9bfed42b48ef15da85d89bab70960 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-6 --allowedTools "Bash(cross test:*),Bash(cross clippy:*),Bash(cross build:*),Bash(cargo fmt:*),Bash(git:*),Bash(gh:*)"'
+          claude_args: '--model claude-opus-4-6 --allowedTools "Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo build:*),Bash(cargo fmt:*),Bash(git:*),Bash(gh:*)"'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,69 +8,65 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  install_dependencies:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Install cross
-      run: cargo install cross --git https://github.com/cross-rs/cross
-
-    - name: Cache dependencies
-      uses: actions/cache@v5
-      with:
-        path: ~/.cargo/bin
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-
   build_and_test:
-    needs: install_dependencies
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
 
-    - name: Restore dependencies from cache
-      uses: actions/cache@v5
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y clang libelf-dev zlib1g-dev
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust artifacts
+      uses: Swatinem/rust-cache@v2
       with:
-        path: ~/.cargo/bin
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+        key: ${{ matrix.target }}
 
     - name: Test
-      run: cross test --target ${{ matrix.target }}
+      run: cargo test
 
     - name: Clippy
-      run: cross clippy --target ${{ matrix.target }} --all --tests --all-features --no-deps
+      run: cargo clippy --all --tests --all-features --no-deps
 
     - name: Build
-      run: cross build --target ${{ matrix.target }} --release
+      if: github.event_name != 'pull_request'
+      run: cargo build --release
 
     - name: Rename binary
-      run: mv target/${{ matrix.target }}/release/bpftop target/${{ matrix.target }}/release/bpftop-${{ matrix.target }}
+      if: github.event_name != 'pull_request'
+      run: mv target/release/bpftop target/release/bpftop-${{ matrix.target }}
 
     - name: Upload artifact
+      if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@v7
       with:
         name: bpftop-${{ matrix.target }}
-        path: target/${{ matrix.target }}/release/bpftop-${{ matrix.target }}
+        path: target/release/bpftop-${{ matrix.target }}
         if-no-files-found: error
 
   create_release:
     needs: build_and_test
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
 
     steps:
     - name: Download all artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,32 +10,17 @@ bpftop is a dynamic real-time view of running eBPF programs written in Rust. It 
 
 ### Building
 ```bash
-# Build for x86_64 (default)
-cross build --release
-
-# Build for ARM64
-cross build --target=aarch64-unknown-linux-gnu --release
-
-# Using make
-make build
+cargo build --release
 ```
 
 ### Testing
 ```bash
-# Run tests for x86_64
-cross test
-
-# Run tests for specific target
-cross test --target=aarch64-unknown-linux-gnu
+cargo test
 ```
 
 ### Code Quality
 ```bash
-# Run clippy linter
-cross clippy --all --tests --all-features --no-deps
-
-# Run clippy for specific target
-cross clippy --target=aarch64-unknown-linux-gnu --all --tests --all-features --no-deps
+cargo clippy --all --tests --all-features --no-deps
 ```
 
 ### Running
@@ -76,7 +61,7 @@ The project uses a build script (`build.rs`) that:
 ### Important Notes
 
 - Requires sudo privileges to run due to BPF syscall requirements
-- Uses `cross` for cross-compilation to support multiple architectures
+- CI uses native GitHub ARM64 runners for aarch64 builds
 - BPF statistics are only collected while the application is running to minimize overhead
 - The UI updates every second with new statistics
 
@@ -84,7 +69,7 @@ The project uses a build script (`build.rs`) that:
 
 ### Rust Style
 - Follow standard `rustfmt` formatting. Run `cargo fmt` before committing.
-- All clippy warnings must pass: `cross clippy --all --tests --all-features --no-deps`
+- All clippy warnings must pass: `cargo clippy --all --tests --all-features --no-deps`
 - Prefer `anyhow::Result` for error propagation. Use `.context()` for meaningful error messages.
 - Every `unsafe` block must have a `// SAFETY:` comment explaining why it is sound.
 - Keep dependencies minimal. This is a single-binary tool — avoid pulling in large frameworks.
@@ -101,4 +86,4 @@ The project uses a build script (`build.rs`) that:
 
 ### Pull Requests
 - PRs must pass CI on both x86_64 and aarch64 before merging.
-- Run `cross clippy` and `cross test` locally to catch issues early.
+- Run `cargo clippy` and `cargo test` locally to catch issues early.

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,0 @@
-[build]
-default-target = "x86_64-unknown-linux-gnu"
-
-[target.x86_64-unknown-linux-gnu]
-dockerfile = "dockerfiles/Dockerfile.x86_64"
-
-[target.aarch64-unknown-linux-gnu]
-dockerfile = "dockerfiles/Dockerfile.aarch64"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: build
 
 build:
-	cross build --release
+	cargo build --release

--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ sudo dnf install -y zlib-devel elfutils-libelf-devel clang libbpf-devel
 
 ### Build Instructions
 
-**For native builds:**
 ```bash
 # Development build
 cargo build
@@ -159,23 +158,6 @@ cargo build
 # Release build
 cargo build --release
 ```
-
-**For cross-compilation:**
-1. Install and setup [cross](https://github.com/cross-rs/cross):
-   ```bash
-   cargo install cross --git https://github.com/cross-rs/cross
-   ```
-
-2. Build for target architectures:
-   ```bash
-   # x86_64
-   cross build --release --target x86_64-unknown-linux-gnu
-   
-   # ARM64
-   cross build --release --target aarch64-unknown-linux-gnu
-   ```
-
-Note: Cross-compilation builds may take 15+ minutes on first run due to Docker image building.
 
 ## Troubleshooting
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -41,13 +41,13 @@ should check these in addition to general code quality.
 - Test that the UI does not panic on zero-length data (no BPF programs
   loaded, empty filter results).
 
-## Cross-compilation
+## Multi-architecture
 
 - CI builds for both `x86_64-unknown-linux-gnu` and
   `aarch64-unknown-linux-gnu`. Do not add platform-specific code without
   gating it behind `#[cfg(target_arch = ...)]`.
 - New dependencies must support both targets. Check before adding.
-- Build changes must work with `cross`, not just `cargo`.
+- Build changes must work with `cargo` on both x86_64 and aarch64.
 
 ## Dependencies
 

--- a/dockerfiles/Dockerfile.aarch64
+++ b/dockerfiles/Dockerfile.aarch64
@@ -1,5 +1,0 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main
-
-RUN apt-get update && apt-get install --assume-yes clang zlib1g-dev libelf-dev
-RUN dpkg --add-architecture arm64
-RUN apt-get update && apt-get install --assume-yes zlib1g-dev:arm64 libelf-dev:arm64

--- a/dockerfiles/Dockerfile.x86_64
+++ b/dockerfiles/Dockerfile.x86_64
@@ -1,3 +1,0 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
-
-RUN apt-get update && apt-get install --assume-yes zlib1g-dev libelf-dev clang


### PR DESCRIPTION
## Summary

- Replace Docker-based `cross` compilation with native GitHub runners (`ubuntu-latest` for x86_64, `ubuntu-24.04-arm` for aarch64)
- Remove `Cross.toml`, `dockerfiles/Dockerfile.x86_64`, and `dockerfiles/Dockerfile.aarch64`
- Remove the `install_dependencies` job that compiled `cross` from source
- Update all documentation (CLAUDE.md, README.md, REVIEW.md, copilot-instructions.md) and the Makefile to use `cargo` instead of `cross`
- Update Claude Code action allowed tools from `cross` to `cargo` commands

## Motivation

The `cross` toolchain added significant overhead to CI:
1. Compiling `cross` from source on every run
2. Building and pulling custom Docker images with BPF dependencies
3. QEMU emulation for aarch64 builds (CPU-bound `rustc` under emulation is slow)

GitHub now provides native ARM64 runners, so we can build natively on both architectures with plain `cargo` and a simple `apt-get install` for BPF dependencies.

## Test plan

- [x] Verify CI passes on both x86_64 and aarch64 matrix jobs
- [x] Verify release artifacts are still correctly named and uploaded