### PR TITLE
ci: add cargo fmt check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,9 @@ jobs:
       with:
         key: ${{ matrix.target }}
 
+    - name: Format
+      run: cargo fmt --all -- --check
+
     - name: Test
       run: cargo test
 


### PR DESCRIPTION
## Summary

- Add `cargo fmt --all -- --check` step to CI, running before test and clippy
- CLAUDE.md already requires `cargo fmt` before committing but CI wasn't enforcing it

## Test plan

- [ ] Verify CI passes on both x86_64 and aarch64