### PR TITLE
chore: bump claude model to opus 4.7

### DIFF
--- a/.github/workflows/claude-ci-helper.yml
+++ b/.github/workflows/claude-ci-helper.yml
@@ -72,7 +72,7 @@ jobs:
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-6 --allowedTools "Bash(gh pr comment:*)"'
+          claude_args: '--model claude-opus-4-7 --allowedTools "Bash(gh pr comment:*)"'
           prompt: |
             The Rust CI workflow failed on PR #${{ github.event.workflow_run.pull_requests[0].number }}.
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -25,7 +25,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-6 --allowedTools "Bash(scripts/triage-issue.sh:*)"'
+          claude_args: '--model claude-opus-4-7 --allowedTools "Bash(scripts/triage-issue.sh:*)"'
           allowed_non_write_users: "*"
           prompt: |
             Triage issue #${{ github.event.issue.number }} using ONLY the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
         uses: anthropics/claude-code-action@0d2971c794049856e777f4e8bb5a81623ec632d3 # v1.0.100
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-6 --allowedTools "Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo build:*),Bash(cargo fmt:*),Bash(git:*),Bash(gh:*)"'
+          claude_args: '--model claude-opus-4-7 --allowedTools "Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo build:*),Bash(cargo fmt:*),Bash(git:*),Bash(gh:*)"'


### PR DESCRIPTION
## Summary
- Bumps all three Claude Code workflows (`claude.yml`, `claude-ci-helper.yml`, `claude-issue-triage.yml`) from `claude-opus-4-6` to `claude-opus-4-7`.

## Test plan
- [ ] Trigger `@claude` on a PR and confirm the action runs against opus 4.7