### PR TITLE
chore: drop procfs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,21 +16,6 @@ name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "anstream"
@@ -162,7 +141,6 @@ dependencies = [
  "libbpf-rs 0.25.0",
  "libbpf-sys",
  "nix",
- "procfs",
  "ratatui",
  "tracing",
  "tracing-journald",
@@ -242,18 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "windows-targets",
-]
-
-[[package]]
 name = "circular-buffer"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,27 +295,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -526,16 +477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,29 +566,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "id-arena"
@@ -899,15 +817,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "mio"
@@ -1163,30 +1072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "procfs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
-dependencies = [
- "bitflags 2.11.0",
- "chrono",
- "flate2",
- "procfs-core",
- "rustix 1.1.3",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
-dependencies = [
- "bitflags 2.11.0",
- "chrono",
- "hex",
 ]
 
 [[package]]
@@ -2085,15 +1970,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,5 @@ anyhow = "1.0.99"
 ratatui = { version = "0.30.0", default-features = false, features = ['crossterm'] }
 nix = { version = "0.29.0", features = ["user", "net"] }
 circular-buffer = "1.1.0"
-procfs = "0.18.0"
 tui-input = "0.15.0"
 clap = { version = "4.5.45", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -240,7 +240,7 @@ impl App {
             match *sort_col {
                 SortColumn::Ascending(col_idx) | SortColumn::Descending(col_idx) => {
                     match col_idx {
-                        1 => items.sort_unstable_by(|a, b| a.bpf_type.cmp(&b.bpf_type)),
+                        1 => items.sort_unstable_by(|a, b| a.bpf_type.cmp(b.bpf_type)),
                         2 => items.sort_unstable_by(|a, b| a.name.cmp(&b.name)),
                         3 => items.sort_unstable_by(|a, b| {
                             a.period_average_runtime_ns()

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ use crossterm::terminal::{
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
 use libbpf_sys::bpf_enable_stats;
 use pid_iter::PidIterSkelBuilder;
-use procfs::KernelVersion;
 use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style, Stylize};
@@ -69,6 +68,7 @@ const SORT_CONTROLS_FOOTER: &str =
 const SORT_INFO_FOOTER: &str = "(Esc) back";
 
 const PROCFS_BPF_STATS_ENABLED: &str = "/proc/sys/kernel/bpf_stats_enabled";
+const PROCFS_KERNEL_OSRELEASE: &str = "/proc/sys/kernel/osrelease";
 
 const TABLE_HEADER_HEIGHT: u16 = 1;
 const TABLE_HEADER_MARGIN: u16 = 1;
@@ -157,16 +157,16 @@ fn main() -> Result<()> {
     // Try to set this subscriber as the global default
     registry.try_init()?;
 
-    let kernel_version = KernelVersion::current()?;
+    let kernel_version = read_kernel_version()?;
     let _owned_fd: OwnedFd;
     let mut stats_enabled_via_procfs = false;
     let mut iter_link = None;
 
     info!("Starting bpftop...");
-    info!("Kernel: {:?}", kernel_version);
+    info!("Kernel: {}.{}", kernel_version.0, kernel_version.1);
 
     // enable BPF stats via syscall if kernel version >= 5.8
-    if kernel_version >= KernelVersion::new(5, 8, 0) {
+    if kernel_version >= (5, 8) {
         let fd = unsafe { bpf_enable_stats(libbpf_sys::BPF_STATS_RUN_TIME) };
         if fd < 0 {
             return Err(anyhow!("Failed to enable BPF stats via syscall"));
@@ -240,6 +240,27 @@ fn procfs_bpf_stats_is_enabled() -> Result<bool> {
     fs::read_to_string(PROCFS_BPF_STATS_ENABLED)
         .context(format!("Failed to read from {PROCFS_BPF_STATS_ENABLED}"))
         .map(|value| value.trim() == "1")
+}
+
+fn read_kernel_version() -> Result<(u32, u32)> {
+    let raw = fs::read_to_string(PROCFS_KERNEL_OSRELEASE)
+        .with_context(|| format!("Failed to read from {PROCFS_KERNEL_OSRELEASE}"))?;
+    parse_kernel_version(raw.trim()).with_context(|| {
+        format!("Failed to parse kernel version from {PROCFS_KERNEL_OSRELEASE}: {raw:?}")
+    })
+}
+
+fn parse_kernel_version(release: &str) -> Result<(u32, u32)> {
+    let mut parts = release.split(['.', '-']);
+    let major = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing major component"))?
+        .parse()?;
+    let minor = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing minor component"))?
+        .parse()?;
+    Ok((major, minor))
 }
 
 fn load_pid_iter(iter_link: &mut Option<libbpf_rs::Link>) -> Result<()> {
@@ -691,5 +712,28 @@ fn render_footer(f: &mut Frame, app: &mut App, area: Rect) {
             f.render_widget(sort_footer, split_area[0]);
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_kernel_version;
+
+    #[test]
+    fn parses_common_osrelease_formats() {
+        assert_eq!(parse_kernel_version("5.15.0").unwrap(), (5, 15));
+        assert_eq!(parse_kernel_version("7.0.1").unwrap(), (7, 0));
+        assert_eq!(parse_kernel_version("5.15.0-78-generic").unwrap(), (5, 15));
+        assert_eq!(parse_kernel_version("6.1.0-rpi7-rpi-v8").unwrap(), (6, 1));
+        assert_eq!(parse_kernel_version("5.8.0").unwrap(), (5, 8));
+        assert_eq!(parse_kernel_version("4.19").unwrap(), (4, 19));
+    }
+
+    #[test]
+    fn rejects_malformed_osrelease() {
+        assert!(parse_kernel_version("").is_err());
+        assert!(parse_kernel_version("5").is_err());
+        assert!(parse_kernel_version("linux-5.15.0").is_err());
+        assert!(parse_kernel_version("5.x").is_err());
     }
 }


### PR DESCRIPTION
## Summary

The `procfs` crate was only used to read and parse `/proc/sys/kernel/osrelease` so we could gate the `bpf_enable_stats` syscall on kernel >= 5.8. That single call pulled in `chrono`, `flate2`, and a handful of platform-specific transitive deps for what amounts to reading a tiny file and parsing two integers.

This PR replaces that with a small `read_kernel_version` helper. Procfs's parser also extracts a patch component, but the only comparison we make is against `(5, 8)` so we can skip it.

Drive-by: dropped a needless `&` in the `bpf_type` sort comparator that clippy was nagging about (`bpf_type` is `Copy`).

## Test plan

- [x] `cargo build`
- [x] `cargo test` (18 tests pass, including 2 new ones for `parse_kernel_version`)
- [x] `cargo clippy --all --tests --all-features --no-deps` (clean — the pre-existing `needless_borrow` warning is also fixed here)
- [x] `cargo fmt --check`
- [x] CI green on x86_64 and aarch64