### PR TITLE
chore: scope the Claude Code workflow to review-only

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,27 +13,30 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
-      id-token: write
-      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@0d2971c794049856e777f4e8bb5a81623ec632d3 # v1.0.100
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-7 --allowedTools "Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo build:*),Bash(cargo fmt:*),Bash(git:*),Bash(gh:*)"'
+          claude_args: '--model claude-opus-4-7 --disallowedTools "Bash"'


### PR DESCRIPTION
## Summary

- Drop bash from the Claude Code workflow's tool allowlist via `--disallowedTools "Bash"` so it relies on the action's built-in commenting tools. Running build tooling on the runner is the job of the existing Rust CI workflow, not this one.
- Gate every trigger to repository collaborators via `author_association`, and downgrade `contents` to `read` since the workflow no longer needs write access.
- Drop the unused `id-token: write` (no OIDC use) and `actions: read` permissions from the Claude workflows, and reduce the checkout to `fetch-depth: 1`.

## Test plan

- [ ] Comment `@claude` on a PR or issue from a collaborator account and confirm the workflow runs and posts a review comment.
- [ ] Confirm a non-collaborator `@claude` mention does not trigger the workflow.