### PR TITLE
chore: bump rand to 0.8.6 to clear GHSA-cq8v-f236-94qc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,9 +1097,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]


### PR DESCRIPTION
Dependabot flagged rand 0.8.5 (advisory GHSA-cq8v-f236-94qc) for an unsoundness that surfaces when a custom log::Log implementation calls into rand::rng() during a ThreadRng reseed. None of those preconditions exist in bpftop: rand is pulled in only as a build-time dependency of phf_generator via ratatui's termwiz backend, and never reaches the runtime binary. The actual security risk here is zero.

Bumping to 0.8.6 still satisfies phf_generator's "^0.8" requirement, so nothing else in the lockfile shifts. Fedora's rust2rpm packaging is unaffected because %cargo_generate_buildrequires resolves against Cargo.toml semver, not our committed lockfile, and %cargo_prep regenerates the lockfile against the system crate registry at RPM build time. The only reason to do this at all is to silence Dependabot and keep the noise floor low when a real advisory lands.