### PR TITLE
fix: restore id-token write for claude workflows

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
The hardening in ad07ed3 dropped id-token: write from the Claude workflows, but the action needs that permission to mint an OIDC token when calling the Anthropic API. Without it the job fails immediately with "unable to get ACTIONS_ID_TOKEN_REQUEST_URL". Add the permission back at the job level only, leaving the rest of the tightening in place.