### PR TITLE
ci: pin release workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,16 +26,16 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y clang libelf-dev zlib1g-dev
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable as of 2026-05-03
 
     - name: Cache Rust artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       with:
         key: ${{ matrix.target }}
 
@@ -58,7 +58,7 @@ jobs:
 
     - name: Upload artifact
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: bpftop-${{ matrix.target }}
         path: target/release/bpftop-${{ matrix.target }}
@@ -74,14 +74,14 @@ jobs:
     steps:
     - name: Download all artifacts
       id: download_artifacts
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         pattern: bpftop-*
         path: artifacts
         merge-multiple: true
 
     - name: Create Release and Upload Artifacts
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
       with:
         artifacts: artifacts/bpftop-*
         draft: true


### PR DESCRIPTION
Pin every action in the release workflow to a commit SHA, with the version recorded in a trailing comment. This follows the standard OpenSSF / GitHub-recommended hardening guidance for workflows that publish artifacts, and keeps future bumps reviewable through dependabot rather than implicit via floating tags.