### PR TITLE
ci: group and throttle github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      interval: monthly
+    groups:
+      github-actions:
+        patterns: ["*"]
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
Per-action weekly PRs from dependabot were creating commit spam on main. Bundle every github-actions bump into a single monthly grouped PR, and drop the minor/patch ignore so the SHA pins added in #230 actually get refreshed when upstream cuts new releases. End state: one grouped PR per month covering everything in .github/workflows, instead of one PR per action per week.